### PR TITLE
Standardize url structure

### DIFF
--- a/innopacks/common/helpers.php
+++ b/innopacks/common/helpers.php
@@ -735,7 +735,16 @@ if (! function_exists('front_route')) {
     function front_route($name, mixed $parameters = [], bool $absolute = true): string
     {
         // Always use locale prefix for consistent URLs
-        return route(front_locale_code().'.front.'.$name, $parameters, $absolute);
+        $routeName = front_locale_code().'.front.'.$name;
+
+        // Check if the route exists with locale prefix
+        if (Route::has($routeName)) {
+            return route($routeName, $parameters, $absolute);
+        }
+
+        // Fallback to non-prefixed route if the prefixed one doesn't exist
+        // This helps with backward compatibility, especially in admin panel
+        return route('front.'.$name, $parameters, $absolute);
     }
 }
 
@@ -765,10 +774,14 @@ if (! function_exists('has_front_route')) {
      */
     function has_front_route($name): bool
     {
-        // Always use locale prefix for consistent URLs
-        $route = front_locale_code().'.front.'.$name;
+        // Check with locale prefix first
+        $routeName = front_locale_code().'.front.'.$name;
+        if (Route::has($routeName)) {
+            return true;
+        }
 
-        return Route::has($route);
+        // Fallback to non-prefixed route
+        return Route::has('front.'.$name);
     }
 }
 
@@ -785,7 +798,15 @@ if (! function_exists('account_route')) {
     function account_route($name, mixed $parameters = [], bool $absolute = true): string
     {
         // Always use locale prefix for consistent URLs
-        return route(front_locale_code().'.front.account.'.$name, $parameters, $absolute);
+        $routeName = front_locale_code().'.front.account.'.$name;
+
+        // Check if the route exists with locale prefix
+        if (Route::has($routeName)) {
+            return route($routeName, $parameters, $absolute);
+        }
+
+        // Fallback to non-prefixed route if the prefixed one doesn't exist
+        return route('front.account.'.$name, $parameters, $absolute);
     }
 }
 

--- a/innopacks/common/helpers.php
+++ b/innopacks/common/helpers.php
@@ -734,10 +734,7 @@ if (! function_exists('front_route')) {
      */
     function front_route($name, mixed $parameters = [], bool $absolute = true): string
     {
-        if (count(locales()) == 1) {
-            return route('front.'.$name, $parameters, $absolute);
-        }
-
+        // Always use locale prefix for consistent URLs
         return route(front_locale_code().'.front.'.$name, $parameters, $absolute);
     }
 }
@@ -768,11 +765,8 @@ if (! function_exists('has_front_route')) {
      */
     function has_front_route($name): bool
     {
-        if (count(locales()) == 1) {
-            $route = 'front.'.$name;
-        } else {
-            $route = front_locale_code().'.front.'.$name;
-        }
+        // Always use locale prefix for consistent URLs
+        $route = front_locale_code().'.front.'.$name;
 
         return Route::has($route);
     }
@@ -790,10 +784,7 @@ if (! function_exists('account_route')) {
      */
     function account_route($name, mixed $parameters = [], bool $absolute = true): string
     {
-        if (count(locales()) == 1) {
-            return route('front.account.'.$name, $parameters, $absolute);
-        }
-
+        // Always use locale prefix for consistent URLs
         return route(front_locale_code().'.front.account.'.$name, $parameters, $absolute);
     }
 }

--- a/innopacks/front/src/Controllers/LocaleController.php
+++ b/innopacks/front/src/Controllers/LocaleController.php
@@ -27,7 +27,15 @@ class LocaleController extends Controller
         $refererUrl  = $request->headers->get('referer');
         $baseUrl     = url('/').'/';
 
-        $newUrl = str_replace($baseUrl.$currentCode, $baseUrl.$destCode, $refererUrl);
+        // Handle URL switching consistently
+        if (strpos($refererUrl, $baseUrl.$currentCode) !== false) {
+            // If URL already has locale prefix, replace it
+            $newUrl = str_replace($baseUrl.$currentCode, $baseUrl.$destCode, $refererUrl);
+        } else {
+            // If URL doesn't have locale prefix, add it
+            $newUrl = str_replace($baseUrl, $baseUrl.$destCode.'/', $refererUrl);
+        }
+
         App::setLocale($destCode);
         session(['locale' => $destCode]);
 

--- a/innopacks/front/src/Controllers/PageController.php
+++ b/innopacks/front/src/Controllers/PageController.php
@@ -24,11 +24,8 @@ class PageController extends Controller
     public function show(Request $request): mixed
     {
         $locale = front_locale_code();
-        if (count(locales()) == 1) {
-            $slug = trim($request->getRequestUri(), '/');
-        } else {
-            $slug = str_replace("/$locale/", '', $request->getRequestUri());
-        }
+        // Always handle URLs with locale prefix for consistency
+        $slug = str_replace("/$locale/", '', $request->getRequestUri());
         $filters = [
             'slug'   => $slug,
             'active' => true,

--- a/innopacks/front/src/FrontServiceProvider.php
+++ b/innopacks/front/src/FrontServiceProvider.php
@@ -117,21 +117,14 @@ class FrontServiceProvider extends ServiceProvider
             });
 
         $locales = locales();
-        if (count($locales) == 1) {
+        // Always register routes with locale prefixes for URL consistency
+        foreach ($locales as $locale) {
             Route::middleware('front')
-                ->name('front.')
+                ->prefix($locale->code)
+                ->name($locale->code.'.front.')
                 ->group(function () {
                     $this->loadRoutesFrom(realpath(__DIR__.'/../routes/web.php'));
                 });
-        } else {
-            foreach ($locales as $locale) {
-                Route::middleware('front')
-                    ->prefix($locale->code)
-                    ->name($locale->code.'.front.')
-                    ->group(function () {
-                        $this->loadRoutesFrom(realpath(__DIR__.'/../routes/web.php'));
-                    });
-            }
         }
     }
 

--- a/innopacks/front/src/FrontServiceProvider.php
+++ b/innopacks/front/src/FrontServiceProvider.php
@@ -106,6 +106,8 @@ class FrontServiceProvider extends ServiceProvider
     {
         $router      = $this->app['router'];
         $middlewares = [SetFrontLocale::class, EventActionHook::class, ContentFilterHook::class, GlobalFrontData::class];
+        // Add the RedirectToLocale middleware to the front group
+        $router->pushMiddlewareToGroup('front', \InnoShop\Front\Middleware\RedirectToLocale::class);
         foreach ($middlewares as $middleware) {
             $router->pushMiddlewareToGroup('front', $middleware);
         }

--- a/innopacks/front/src/Middleware/RedirectToLocale.php
+++ b/innopacks/front/src/Middleware/RedirectToLocale.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright (c) Since 2024 InnoShop - All Rights Reserved
+ *
+ * @link       https://www.innoshop.com
+ * @author     InnoShop <team@innoshop.com>
+ * @license    https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace InnoShop\Front\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class RedirectToLocale
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     * @throws \Exception
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        // Get the first segment of the URL (potential locale)
+        $segment = $request->segment(1);
+        
+        // Get available locales
+        $availableLocales = locales()->pluck('code')->toArray();
+        
+        // If the first segment is not a valid locale, redirect to the default locale
+        if (!in_array($segment, $availableLocales)) {
+            // Get the default locale
+            $defaultLocale = setting_locale_code();
+            
+            // Get the full path
+            $path = $request->path();
+            if ($path === '/') {
+                $path = '';
+            }
+            
+            // Redirect to the same path with the default locale prefix
+            return redirect()->to('/' . $defaultLocale . ($path ? '/' . $path : ''));
+        }
+        
+        return $next($request);
+    }
+}

--- a/innopacks/front/src/Services/SitemapService.php
+++ b/innopacks/front/src/Services/SitemapService.php
@@ -137,10 +137,7 @@ class SitemapService extends BaseService
      */
     private function frontRoute($locale, $name, mixed $parameters = []): string
     {
-        if (count(locales()) == 1) {
-            return route('front.'.$name, $parameters);
-        }
-
+        // Always use locale prefix for consistent URLs
         return route($locale.'.front.'.$name, $parameters);
     }
 }

--- a/innopacks/plugin/src/PluginServiceProvider.php
+++ b/innopacks/plugin/src/PluginServiceProvider.php
@@ -267,21 +267,14 @@ class PluginServiceProvider extends ServiceProvider
         $frontRoutePath = "$pluginBasePath/$pluginCode/Routes/front.php";
         if (file_exists($frontRoutePath)) {
             $locales = locales();
-            if (count($locales) == 1) {
+            // Always register routes with locale prefixes for URL consistency
+            foreach ($locales as $locale) {
                 Route::middleware('front')
-                    ->name('front.')
+                    ->prefix($locale->code)
+                    ->name($locale->code.'.front.')
                     ->group(function () use ($frontRoutePath) {
                         $this->loadRoutesFrom($frontRoutePath);
                     });
-            } else {
-                foreach ($locales as $locale) {
-                    Route::middleware('front')
-                        ->prefix($locale->code)
-                        ->name($locale->code.'.front.')
-                        ->group(function () use ($frontRoutePath) {
-                            $this->loadRoutesFrom($frontRoutePath);
-                        });
-                }
             }
         }
     }


### PR DESCRIPTION
The Problem with URL Prefixing:
```
The issue is in your FrontServiceProvider.php and related files. When you have only one language, the system doesn't use locale prefixes in URLs (like /products). But when you add a second language, it switches to using prefixes (like /en/products, /fr/products).

This inconsistency breaks all bookmarks and saved links when you add or remove languages, because the URL structure completely changes.
```

Benefits:
```
Bookmark Stability - Links and bookmarks continue to work when adding/removing languages

Simplified Code - Eliminated conditional logic, making the codebase cleaner and more maintainable

Consistent User Experience - Users see predictable URL patterns regardless of language configuration

SEO Advantages - Better indexing of multilingual content and avoids duplicate content issues

Future-Proofing - Application is prepared for language changes without breaking existing functionality

The core improvement is consistency - by always using locale prefixes in URLs (like /en/products), your system behaves predictably regardless of how many languages are configured.
```