### PR TITLE
fix: prevent pre-auth application reinstall takeover

### DIFF
--- a/innopacks/install/src/InstallServiceProvider.php
+++ b/innopacks/install/src/InstallServiceProvider.php
@@ -29,8 +29,11 @@ class InstallServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // 安全修复: 系统已安装后，不再注册安装路由，防止未授权重装攻击
-        if (installed()) {
+        // Security fix: skip installer route registration after installation
+        // to prevent unauthenticated reinstall/takeover attacks.
+        // Use has_install_lock() instead of installed() to avoid DB dependency,
+        // ensuring routes stay blocked even during database outages.
+        if (has_install_lock()) {
             return;
         }
 

--- a/innopacks/install/src/InstallServiceProvider.php
+++ b/innopacks/install/src/InstallServiceProvider.php
@@ -29,6 +29,11 @@ class InstallServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // 安全修复: 系统已安装后，不再注册安装路由，防止未授权重装攻击
+        if (installed()) {
+            return;
+        }
+
         $this->registerWebRoutes();
         $this->loadTranslations();
     }

--- a/innopacks/install/src/InstallServiceProvider.php
+++ b/innopacks/install/src/InstallServiceProvider.php
@@ -29,10 +29,6 @@ class InstallServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Security fix: skip installer route registration after installation
-        // to prevent unauthenticated reinstall/takeover attacks.
-        // Use has_install_lock() instead of installed() to avoid DB dependency,
-        // ensuring routes stay blocked even during database outages.
         if (has_install_lock()) {
             return;
         }


### PR DESCRIPTION
## Summary

Add an `installed()` guard to `InstallServiceProvider::boot()` to prevent registration of installation routes after the application has been installed. This fixes a **critical pre-authentication vulnerability** that allows unauthenticated attackers to completely take over an InnoShop instance.

## Problem

The installation routes (`/install`, `/install/complete`) remain accessible without any authentication after the application is fully installed. An attacker can send a single unauthenticated POST request to `/install/complete` to:

1. Overwrite the `.env` file (including `APP_KEY`)
2. Execute `migrate:fresh` — **dropping all database tables**
3. Create a new admin account with attacker-controlled credentials
4. Gain full admin panel access → Remote Code Execution via plugin upload

## Fix

```php
// innopacks/install/src/InstallServiceProvider.php
public function boot(): void
{
    if (installed()) {
        return; // Block all install routes after installation
    }
    
    $this->registerWebRoutes();
    $this->loadTranslations();
}
