### PR TITLE
refactor: remove openai-php/client dependency and dead AI service classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "maatwebsite/excel": "^3.1",
         "mobiledetect/mobiledetectlib": "^4.8",
         "nelexa/zip": "^4.0",
-        "openai-php/client": "^0.15.0",
         "overtrue/easy-sms": "^3.2",
         "parsedown/parsedown": "^1.8",
         "phpunit/php-timer": "^7.0",

--- a/innopacks/common/src/Services/AI/AIServiceManager.php
+++ b/innopacks/common/src/Services/AI/AIServiceManager.php
@@ -311,15 +311,15 @@ class AIServiceManager
     public function getAvailableModels(): array
     {
         $models = [
-            'openai'    => OpenAIService::class,
-            'anthropic' => OpenAIService::class,
-            'deepseek'  => OpenAIService::class,
-            'kimi'      => OpenAIService::class,
-            'doubao'    => OpenAIService::class,
-            'qianwen'   => OpenAIService::class,
-            'hunyuan'   => OpenAIService::class,
-            'glm'       => GlmService::class,
-            'minimax'   => MinimaxService::class,
+            'openai'    => LaravelAIService::class,
+            'anthropic' => LaravelAIService::class,
+            'deepseek'  => LaravelAIService::class,
+            'kimi'      => LaravelAIService::class,
+            'doubao'    => LaravelAIService::class,
+            'qianwen'   => LaravelAIService::class,
+            'hunyuan'   => LaravelAIService::class,
+            'glm'       => LaravelAIService::class,
+            'minimax'   => LaravelAIService::class,
         ];
 
         $result = [];


### PR DESCRIPTION
## Summary
- 移除 `openai-php/client` 依赖，项目已全面使用 `laravel/ai` SDK
- 删除不再使用的旧 AI 服务类：`OpenAIService.php`、`GlmService.php`、`MinimaxService.php`
- 更新 `AIServiceManager::getAvailableModels()` 引用，统一指向 `LaravelAIService`

## 背景
所有 AI 调用已通过 Laravel AI SDK (`LaravelAIService`) 处理，GLM/Minimax 也已在 `AppServiceProvider` 中通过 `\Laravel\Ai\Ai::extend()` 注册。旧的三个 Service 类不再被实例化，仅 `getAvailableModels()` 中有静态引用。

## 改动文件
- **删除** `innopacks/common/src/Services/AI/OpenAIService.php`
- **删除** `innopacks/common/src/Services/AI/GlmService.php`
- **删除** `innopacks/common/src/Services/AI/MinimaxService.php`
- **修改** `innopacks/common/src/Services/AI/AIServiceManager.php`
- **修改** `composer.json` (移除 `openai-php/client`)

## Test plan
- [ ] 确认后台 AI 设置页面正常加载
- [ ] 测试各 AI 模型（OpenAI/DeepSeek/GLM/Minimax 等）生成内容功能
- [ ] 运行 `composer install` 确认无依赖冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)