### PR TITLE
fix: add missing active rule to ArticleRequest so API can activate articles

### DIFF
--- a/innopacks/panel/src/Requests/ArticleRequest.php
+++ b/innopacks/panel/src/Requests/ArticleRequest.php
@@ -47,6 +47,7 @@ class ArticleRequest extends FormRequest
             'position'   => 'integer',
             'viewed'     => 'integer',
             'image'      => 'nullable|string|max:500',
+            'active'     => 'boolean',
 
             "translations.$defaultLocale.locale"  => 'required',
             "translations.$defaultLocale.title"   => 'required',


### PR DESCRIPTION
## Problem
`PATCH /api/panel/articles/{id}` with `active=1` returns "updated successfully", but `active` is not listed in `ArticleRequest::rules()`, so `$request->validated()` silently drops it. Articles can never be activated via the Panel API — they stay `active=0` and the front-end detail page (`/article-{slug}`) returns 404.

## Fix
Add `'active' => 'boolean'` to the validation rules.

## Verification
- Reproduced on a production store: two articles stuck at `active=0` despite successful PATCH responses; after adding the rule, PATCH activates them and detail pages return 200.
- `php -l` passes.